### PR TITLE
Correct debugging cloud formation url

### DIFF
--- a/lib/jets/cfn/ship.rb
+++ b/lib/jets/cfn/ship.rb
@@ -38,7 +38,7 @@ module Jets::Cfn
           The logs above show the CloudFormation parent stack events and points to the stack with the error.
           Please go to the CloudFormation console and look for the specific stack with the error.
           The specific child stack usually shows more detailed information and can be used to resolve the issue.
-          Example of checking the CloudFormation console: http://rubyonjets.com/docs/debugging-cloudformation/
+          Example of checking the CloudFormation console: https://rubyonjets.com/docs/debugging/cloudformation/
         EOL
         return
       end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When deploying jets is failed by cloud formation issue, the console shows [a debugging cloud formation docs url](https://rubyonjets.com/docs/debugging-cloudformation/). But this url is not found 404. So I change it into [worked url](https://rubyonjets.com/docs/debugging/cloudformation/).

## Context

* [Current not worked Debugging CloudFormation Jets Docs Link](https://rubyonjets.com/docs/debugging-cloudformation/)
* [Worked Debugging CloudFormation Jets Docs Link](https://rubyonjets.com/docs/debugging/cloudformation/)

## Version Changes

This is so minor changes.